### PR TITLE
Centralized font configuration and added enhancement for blog to edit page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,6 @@ paige:
     }
     #paige-collections,
     #paige-sections
-  color: "#6831f5"
 title: "PBJ Writes ✍🏻"
 ---
 <br>

--- a/content/blog/2024-01-07-zwift_weight.md
+++ b/content/blog/2024-01-07-zwift_weight.md
@@ -4,7 +4,6 @@ description: "Avoiding weight anxiety and obsession."
 paige:
   file_link:
     disable: false
-  color: "#6831f5"
   style: |
     #paige-authors,
     #paige-date,

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -2,6 +2,7 @@
 title: "Blog"
 description: "Musings on sport, writing, and life."
 paige:
-  color: "#6831f5"
+  file_link:
+    disable: false
 ---
   

--- a/content/mystory/_index.md
+++ b/content/mystory/_index.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 <html>
 <head>

--- a/content/mystory/pbj_the_athlete.md
+++ b/content/mystory/pbj_the_athlete.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 <html>
 <head>

--- a/content/mystory/pbj_the_professional.md
+++ b/content/mystory/pbj_the_professional.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 <html>
 <head>

--- a/content/portfolio/_index.md
+++ b/content/portfolio/_index.md
@@ -1,6 +1,5 @@
 ---
 paige:
-  color: "#6831f5"
   layout: "paige/cloud"
 ---
 

--- a/content/portfolio/diagram_samples.md
+++ b/content/portfolio/diagram_samples.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 
 # Diagram Samples

--- a/content/portfolio/editing_samples/index.md
+++ b/content/portfolio/editing_samples/index.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 
 # Editing Samples

--- a/content/portfolio/how-to.md
+++ b/content/portfolio/how-to.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 # how-to
 

--- a/content/portfolio/style_guide_sample/index.md
+++ b/content/portfolio/style_guide_sample/index.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 # Style Guide Sample
 In all my professional positions, I have contributed to a style guide or manual of some sort. I am posting my first style manual work which is a format and regulation guide for students to follow for their electronic theses and dissertations (ETDs).

--- a/content/portfolio/video_instructions.md
+++ b/content/portfolio/video_instructions.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 Granted these are from the time of different screen sizes and at least seven years old but I worked with what I had at a public university to create instructions for graduate students to aid in the formatting and submission of electronic theses and dissertations (ETD).
 

--- a/content/portfolio/word_templates/index.md
+++ b/content/portfolio/word_templates/index.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 <script src= '/js/pdf-js/build/pdf.js'></script>
 # Word Templates

--- a/content/resume/_index.md
+++ b/content/resume/_index.md
@@ -1,6 +1,5 @@
 ---
-paige:
-  color: "#6831f5"
+
 ---
 <html>
 <head>
@@ -18,14 +17,14 @@ th, td {
 </style>
 </head>
 
-## <font style="color:#6831f5">Summary</font>
+## Summary
 Senior <b>technical writer</b> with DevOps, data science, and QA experience seeking a company that aspires to change the world through innovation and sustainability.
 
 ---
 
-## <font style="color:#6831f5">Experience</font>
+## Experience
 
-### <font style="color:#EBB9EF">FICO</font> 
+### FICO
 
 #### <b>Lead Technical Writer</b>
 <p>June 2021 - present | Los Angeles, CA</p>
@@ -62,7 +61,7 @@ Senior <b>technical writer</b> with DevOps, data science, and QA experience seek
 
 ---
 
-### <font style="color:#EBB9EF">Marathon TS</font>
+### Marathon TS
 #### <b>Technical Writer III</b> <font style="font-size:0.75vw">assigned to the Joint Operational Medicine Information Systems ([JOMIS](https://www.health.mil/Reference-Center/Fact-Sheets/2023/03/23/PEO-DHMS-Fact-Sheet-JOMIS)) program for the Department of Defense</font>
 <p>January 2016 - July 2017 | Rosslyn, VA</p>
 <b>KEY PROJECTS</b>
@@ -77,7 +76,7 @@ Senior <b>technical writer</b> with DevOps, data science, and QA experience seek
 
 ---
 
-### <font style="color:#EBB9EF">Bechtel Marine Propulsion Corporation (BMPC)</font>
+### Bechtel Marine Propulsion Corporation (BMPC)
 
 #### <b>Intermediate Technical Editor</b> <font style="font-size:0.75vw">contractor at the [Knolls Atomic Power Laboratory](https://navalnuclearlab.energy.gov/knolls-atomic-power-laboratory/) for a Navy and Department of Energy contract</font>
 <p></p>April 2014 - January 2016 | Niskayuna, NY</p>
@@ -95,7 +94,7 @@ Senior <b>technical writer</b> with DevOps, data science, and QA experience seek
 
 ---
 
-### <font style="color:#EBB9EF">Florida International University (FIU)</font>
+### Florida International University (FIU)
 #### <b>Electronic Theses and Dissertations Coordinator</b>
 June 2011 - January 2014 | Miami, FL
 <p><b>KEY PROJECTS</b></p>
@@ -113,17 +112,17 @@ June 2011 - January 2014 | Miami, FL
 
 ---
 
-## <font style="color:#6831f5">Education</font>
-### <font style="color:#EBB9EF">Syracuse University 🍊</font>
+## Education
+### Syracuse University 🍊
 <p><b>Certificate of Advanced Study in Digital Libraries</b></p>
 <p><b>M.S. Library and Information Science</b></p>
 
-### <font style="color:#EBB9EF">State University of New York at Cortland 🐲</font>
+### State University of New York at Cortland 🐲
 <p><b>B.A. Professional Writing and Social Philosophy</b></p>
 
 ---
 
-## <font style="color:#6831f5">Technical Skills</font>
+## Technical Skills
 
 |<b>TOOL GROUP</b>|<b>TOOLS</b>|
 |-|-|
@@ -135,5 +134,5 @@ June 2011 - January 2014 | Miami, FL
 
 ---
 
-## <font style="color:#6831f5">Contact</font>
+## Contact
 pbj dot writes at gmail dot com

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,8 +7,12 @@ theme = 'paige'
 titlecasestyle = "Go"
 enablerobotstxt = true
 
-[outputs]
-home = ["html", "json", "rss"]
+[params.paige]
+color = "#6831f5"
+external_link_new_tab = true
+
+[params.paige.menu]
+style = "tabs" # Must be "links", "pills", "tabs", or "underline"
 
 [markup.goldmark.renderer]
 unsafe = true
@@ -137,3 +141,19 @@ series = "series"
 
 [permalinks]
 blog = "/:year/:month/:day/:title/"
+
+[outputs]
+home = ["html", "json", "rss"]
+section = ["html", "rss"]
+taxonomy = ["html", "rss"]
+
+[[module.imports]]
+path = "github.com/pbj-writes/hugo_portfolio"
+
+[params.paige.git]
+commit_url = "https://github.com/pbj-writes/hugo_portfolio/commit/%s"
+
+[params.paige.file_link]
+content = "Edit this page"
+disable = true
+url = "https://github.com/pbj-writes/hugo_portfolio/edit/main/content/%s"

--- a/layouts/partials/paige/style-first.css
+++ b/layouts/partials/paige/style-first.css
@@ -17,3 +17,6 @@
 .paige-summary {
     display: none;
 }
+
+h2 {color: #A483F9 !important}
+h3 {color: #EBB9EF !important}

--- a/themes/paige/layouts/_default/_markup/render-link.html
+++ b/themes/paige/layouts/_default/_markup/render-link.html
@@ -1,0 +1,6 @@
+{{- $href := cond (.Destination | not | not) (printf ` href="%s"` .Destination) "" -}}
+{{- $target := partial "paige/target.html" (dict "page" .Page "url" .Destination) -}}
+{{- $targetattr := cond ($target | not | not) (printf ` target="%s"` $target) "" -}}
+{{- $title := cond (.Title | not | not) (printf ` title="%s"` .Title) "" -}}
+
+{{- printf `<a%s%s%s>%s</a>` $href $targetattr $title .Text | safeHTML -}}

--- a/themes/paige/layouts/_default/list.atom.xml
+++ b/themes/paige/layouts/_default/list.atom.xml
@@ -1,0 +1,222 @@
+{{ $page := . }}
+
+{{ $authors := $page.Param "paige.feed.atom.authors" }}
+{{ $format := "2006-01-02T15:04:05Z07:00" }}
+{{ $html := $page.AlternativeOutputFormats.Get "html" }}
+{{ $icon := $page.Param "paige.feed.atom.icon" }}
+{{ $id := "" }}
+{{ $ids := dict }}
+{{ $language := site.LanguageCode | default site.Language.Lang }}
+{{ $limit := site.Config.Services.RSS.Limit }}
+{{ $logo := $page.Param "paige.feed.atom.logo" }}
+{{ $pagetitle := $page.Title | markdownify }}
+{{ $rights := site.Copyright | markdownify }}
+{{ $sitetitle := site.Title | markdownify }}
+{{ $subpages := slice }}
+{{ $subtitle := $page.Description | markdownify }}
+{{ $updated := site.LastChange.Format $format }}
+
+{{ if $icon }}
+    {{ $icon = absLangURL $icon }}
+{{ end }}
+
+{{ if $page.Params.id }}
+    {{ $id = printf "%s?id=%v" (urls.JoinPath site.BaseURL "/") $page.Params.id }}
+{{ else if not $page.Date.IsZero }}
+    {{ $id = printf "tag:%s,%s:%s" (urls.Parse site.BaseURL).Host ($page.Date.Format "2006-01-02") ($page.Date.Format $format) }}
+{{ else }}
+    {{ $id = $page.Permalink }}
+{{ end }}
+
+{{ if $logo }}
+    {{ $logo = absLangURL $logo }}
+{{ end }}
+
+{{ range (cond $page.IsHome site $page).RegularPages }}
+    {{ if not (.Param "paige.feed.hide_page") }}
+        {{ $subpages = $subpages | append . }}
+    {{ end }}
+{{ end }}
+
+{{ if gt $limit 0 }}
+    {{ $subpages = $subpages | first $limit }}
+{{ end }}
+
+{{ $titles := slice ($page.Title | markdownify) }}
+
+{{ range .Ancestors }}
+    {{ $titles = $titles | append (.Title | markdownify) }}
+{{ end }}
+
+{{ $title := delimit $titles " · " }}
+
+{{ if not $title }}
+    {{ warnf "layouts/_default/list.atom.xml: page %s does not have a title" $page.RelPermalink }}
+{{ end }}
+
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>" | safeHTML }}
+<feed {{ with $language }} xml:lang="{{ . }}" {{ end }} xmlns="http://www.w3.org/2005/Atom">
+    {{ range $authors }}
+        <author>
+            {{ with .email }}
+                <email>{{ . }}</email>
+            {{ end }}
+
+            {{ with .name }}
+                <name>{{ . }}</name>
+            {{ end }}
+
+            {{ with .url }}
+                <uri>{{ . }}</uri>
+            {{ end }}
+        </author>
+    {{ end }}
+
+    {{ with $icon }}
+        <icon>{{ . }}</icon>
+    {{ end }}
+
+    <id>{{ $id }}</id>
+
+    {{ range $page.OutputFormats }}
+        {{ $rel := .Rel }}
+
+        {{ if eq .Permalink $page.Permalink }}
+            {{ $rel = "self" }}
+        {{ else if eq $rel "canonical" }}
+            {{ $rel = "alternate" }}
+        {{ end }}
+
+        {{ if or (eq $rel "alternate") (eq $rel "enclosure") (eq $rel "related") (eq $rel "self") (eq $rel "via") }}
+            {{ printf `<link href="%s" rel="%s" type="%s"/>` .Permalink $rel .MediaType | safeHTML }}
+        {{ end }}
+    {{ end }}
+
+    {{ range $t := $page.Translations }}
+        {{ range .OutputFormats }}
+            {{ if or (eq .Rel "alternate") (eq .Rel "enclosure") (eq .Rel "related") (eq .Rel "via") }}
+                {{ printf `<link href="%s" hreflang="%s" rel="%s" type="%s"/>` .Permalink $t.Lang .Rel .MediaType | safeHTML }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+
+    {{ with $logo }}
+        <logo>{{ . }}</logo>
+    {{ end }}
+
+    {{ with $rights }}
+        <rights type="html">{{ printf "<![CDATA[%s]]>" . | safeHTML }}</rights>
+    {{ end }}
+
+    {{ with $subtitle }}
+        <subtitle type="html">{{ printf "<![CDATA[%s]]>" . | safeHTML}}</subtitle>
+    {{ end }}
+
+    {{ printf `<title type="html"><![CDATA[%s]]></title>` $title | safeHTML }}
+    <updated>{{ $updated }}</updated>
+
+    {{ range $subpage := $subpages }}
+        <entry>
+            {{ $content := .Content }}
+            {{ $id := "" }}
+            {{ $paramlink := and .Params.link (not (.Param "paige.feed.link_to_page")) | not | not }}
+            {{ $published := cond (not .PublishDate.IsZero) (.PublishDate.Format $format) "" }}
+            {{ $rights := site.Copyright | markdownify }}
+            {{ $summary := .Description | markdownify }}
+            {{ $title := .Title | markdownify }}
+            {{ $updated := .Lastmod.Format $format }}
+
+            {{ $link := cond $paramlink .Params.link .Permalink }}
+
+            {{ if and $content $paramlink }}
+                {{ $link := or (.Param "paige.feed.page_link" | markdownify) "⏎" }}
+                {{ $footer := printf `<p><a href="%s" title="%s">%s</a></p>` .Permalink (htmlEscape .Title) $link }}
+
+                {{ $content = print $content $footer }}
+            {{ end }}
+
+            {{ if not $content }}
+                {{ $content = .Description | markdownify}}
+            {{ end }}
+
+            {{ if .Params.id }}
+                {{ $id = printf "%s?id=%v" (urls.JoinPath site.BaseURL "/") .Params.id }}
+            {{ else if not .Date.IsZero }}
+                {{ $id = printf "tag:%s,%s:%s" (urls.Parse site.BaseURL).Host (.Date.Format "2006-01-02") (.Date.Format $format) }}
+            {{ else }}
+                {{ $id = .Permalink }}
+            {{ end }}
+
+            {{ with index $ids $id }}
+                {{ warnf "layouts/_default/list.atom.xml: pages %s and %s have the same ID" . $subpage.RelPermalink }}
+            {{ end }}
+
+            {{ $ids = merge (dict $id .RelPermalink) $ids }}
+
+            {{ if not $title }}
+                {{ warnf "layouts/_default/list.atom.xml: page %s does not have a title" .RelPermalink }}
+            {{ end }}
+
+            {{ if .Lastmod.IsZero }}
+                {{ warnf "layouts/_default/list.atom.xml: page %s does not have a modified date" .RelPermalink }}
+            {{ end }}
+
+            {{ with partial "paige/authors.html" . }}
+                {{ range . }}
+                    <author>
+                        {{ with .email }}
+                            <email>{{ . }}</email>
+                        {{ end }}
+
+                        {{ with .name }}
+                            <name>{{ . }}</name>
+                        {{ end }}
+
+                        {{ with .url }}
+                            <uri>{{ . }}</uri>
+                        {{ end }}
+                    </author>
+                {{ end }}
+            {{ end }}
+
+            {{ with $content }}
+                <content type="html">{{ printf "<![CDATA[%s]]>" . | safeHTML }}</content>
+            {{ end }}
+
+            <id>{{ $id }}</id>
+
+            {{ range .OutputFormats }}
+                {{ $rel := cond (eq .Rel "canonical") "alternate" .Rel }}
+
+                {{ if or (eq $rel "alternate") (eq $rel "enclosure") (eq $rel "related") (eq $rel "via") }}
+                    {{ $href := cond (and (eq $rel "alternate") (eq .MediaType.Type "text/html")) $link .Permalink }}
+
+                    <link href="{{ $href }}" rel="{{ $rel }}" type="{{ .MediaType }}"/>
+                {{ end }}
+            {{ end }}
+
+            {{ range $t := .Translations }}
+                {{ range .OutputFormats }}
+                    {{ if or (eq .Rel "alternate") (eq .Rel "enclosure") (eq .Rel "related") (eq .Rel "via") }}
+                        <link href="{{ .Permalink }}" hreflang="{{ $t.Lang }}" rel="{{ .Rel }}" type="{{ .MediaType }}"/>
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+
+            {{ with $published }}
+                <published>{{ . }}</published>
+            {{ end }}
+
+            {{ with $rights }}
+                <rights type="html">{{ printf "<![CDATA[%s]]>" . | safeHTML }}</rights>
+            {{ end }}
+
+            {{ with $summary }}
+                <summary type="html">{{ printf "<![CDATA[%s]]>" . | safeHTML }}</summary>
+            {{ end }}
+
+            {{ printf `<title type="html"><![CDATA[%s]]></title>` $title | safeHTML }}
+            <updated>{{ $updated }}</updated>
+        </entry>
+    {{ end }}
+</feed>

--- a/themes/paige/layouts/_default/list.rss.xml
+++ b/themes/paige/layouts/_default/list.rss.xml
@@ -1,0 +1,152 @@
+{{ $page := . }}
+
+{{ $copyright := site.Copyright }}
+{{ $description := or $page.Description "Recent content" }}
+{{ $feed := ($page.OutputFormats.Get "rss").Permalink }}
+{{ $format := "Mon, 02 Jan 2006 15:04:05 MST" }}
+{{ $guids := dict }}
+{{ $html := $page.AlternativeOutputFormats.Get "html" }}
+{{ $language := site.LanguageCode | default site.Language.Lang }}
+{{ $lastbuilddate := (partial "paige/changed.html" $page).Format $format }}
+{{ $limit := site.Config.Services.RSS.Limit }}
+{{ $link := ($page.AlternativeOutputFormats.Get "html").Permalink }}
+{{ $managingeditor := $page.Param "paige.feed.rss.managing_editor" }}
+{{ $pagetitle := $page.Title | markdownify | plainify | htmlUnescape }}
+{{ $sitetitle := site.Title | markdownify | plainify | htmlUnescape }}
+{{ $subpages := slice }}
+{{ $webmaster := $page.Param "paige.feed.rss.web_master" }}
+
+{{ range (cond $page.IsHome site $page).RegularPages }}
+    {{ if not (.Param "paige.feed.hide_page") }}
+        {{ $subpages = $subpages | append . }}
+    {{ end }}
+{{ end }}
+
+{{ if gt $limit 0 }}
+    {{ $subpages = $subpages | first $limit }}
+{{ end }}
+
+{{ $titles := slice ($page.Title | markdownify) }}
+
+{{ range .Ancestors }}
+    {{ $titles = $titles | append (.Title | markdownify) }}
+{{ end }}
+
+{{ $title := delimit $titles " · " }}
+
+{{ if not $title }}
+    {{ warnf "layouts/_default/rss.xml: page %s does not have a title" $page.RelPermalink }}
+{{ end }}
+
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>" | safeHTML }}
+<rss version="2.0" {{ with $language }} xml:lang="{{ . }}" {{ end }} xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <atom:link href="{{ $feed }}" rel="self" type="application/rss+xml"/>
+
+        {{ with $copyright }}
+            <copyright>{{ . }}</copyright>
+        {{ end }}
+
+        <description>{{ $description }}</description>
+
+        {{ with $language }}
+            <language>{{ . }}</language>
+        {{ end }}
+
+        {{ with $lastbuilddate }}
+            <lastBuildDate>{{ . }}</lastBuildDate>
+        {{ end }}
+
+        <link>{{ $link }}</link>
+
+        {{ with $managingeditor }}
+            <managingEditor>{{ . }}</managingEditor>
+        {{ end }}
+
+        <title>{{ $title }}</title>
+
+        {{ with $webmaster }}
+            <webMaster>{{ . }}</webMaster>
+        {{ end }}
+
+        {{ range $subpage := $subpages }}
+            <item>
+                {{ $author := "" }}
+                {{ $authors := partial "paige/authors.html" . }}
+                {{ $description := .Content }}
+                {{ $guid := "" }}
+                {{ $paramlink := and .Params.link (not (.Param "paige.feed.link_to_page")) | not | not }}
+                {{ $permalink := false }}
+                {{ $pubdate := .PublishDate.Format $format }}
+                {{ $title := .Title | markdownify | plainify | htmlUnescape }}
+
+                {{ $link := cond $paramlink .Params.link .Permalink }}
+
+                {{ with $authors }}
+                    {{ $primary := index . 0 }}
+
+                    {{ if and $primary.name $primary.email }}
+                        {{ $author = printf "%s (%s)" $primary.email $primary.name }}
+                    {{ else if $primary.email }}
+                        {{ $author = $primary.email }}
+                    {{ end }}
+                {{ end }}
+
+                {{ if and $description $paramlink }}
+                    {{ $pagelink := or (.Param "paige.feed.page_link" | markdownify) "⏎" }}
+                    {{ $footer := printf `<p><a href="%s" title="%s">%s</a></p>` .Permalink (htmlEscape $title) $pagelink }}
+
+                    {{ $description = print $description $footer }}
+                {{ end }}
+
+                {{ if not $description }}
+                    {{ $description = .Description | markdownify}}
+                {{ end }}
+
+                {{ $description = $description | replaceRE `<a href="#fn:(\d+)" class="footnote-ref" role="doc-noteref">` (printf `<a href="%s#fn:$1" class="footnote-ref" role="doc-noteref">` .Permalink) }}
+                {{ $description = $description | replaceRE `<a href="#fnref:(\d+)" class="footnote-backref" role="doc-backlink">` (printf `<a href="%s#fnref:$1" class="footnote-backref" role="doc-backlink">` .Permalink) }}
+
+                {{ if and (not $description) (not $title) }}
+                    {{ warnf "layouts/_default/rss.xml: page %s does not have a title or description" .RelPermalink }}
+                {{ end }}
+
+                {{ if .Params.id }}
+                    {{ $guid = .Params.id }}
+                {{ else if not .Date.IsZero }}
+                    {{ $guid = printf "tag:%s,%s:%s" (urls.Parse site.BaseURL).Host (.Date.Format "2006-01-02") (.Date.Format "2006-01-02T15:04:05Z07:00") }}
+                {{ else }}
+                    {{ $guid = .Permalink }}
+                    {{ $permalink = false }}
+                {{ end }}
+
+                {{ with index $guids $guid }}
+                    {{ warnf "layouts/_default/rss.xml: pages %s and %s have the same GUID" . $subpage.RelPermalink }}
+                {{ end }}
+
+                {{ $guids = merge (dict $guid .RelPermalink) $guids }}
+
+                {{ with $author }}
+                    <author>{{ . }}</author>
+                {{ end }}
+
+                {{ with $description }}
+                    <description>{{ printf "<![CDATA[%s]]>" . | safeHTML }}</description>
+                {{ end }}
+
+                <guid {{ if not $permalink }} isPermaLink="false" {{ end }}>{{ $guid }}</guid>
+
+                {{ with $link }}
+                    <link>{{ . }}</link>
+                {{ end }}
+
+                {{ with $pubdate }}
+                    <pubDate>{{ . }}</pubDate>
+                {{ end }}
+
+                {{ with $title }}
+                    <title>{{ . }}</title>
+                {{ end }}
+            </item>
+        {{ end }}
+    </channel>
+</rss>

--- a/themes/paige/layouts/partials/paige/footer.html
+++ b/themes/paige/layouts/partials/paige/footer.html
@@ -1,5 +1,14 @@
 {{ $page := . }}
 
+{{ $href := "https://github.com/pbj-writes/hugo_portfolio" }}
+{{ $linkcontent := $page.Param "paige.file_link.content" | markdownify }}
+{{ $linkurl := $page.Param "paige.file_link.url" }}
+{{ $target := partial "paige/target.html" (dict "page" $page "url" $href) }}
+
+{{ if and $linkurl $page.File }}
+    {{ $linkurl = printf $linkurl $page.File.Path | safeURL }}
+{{ end }}
+
 <footer class="mb-3" id="paige-footer">
     {{ if templates.Exists "partials/paige/footer-first.html" }}
         {{ partial "paige/footer-first.html" . }}
@@ -7,6 +16,12 @@
 
     {{ with site.Copyright | markdownify }}
         <p class="mb-0 text-center text-secondary" id="paige-copyright">{{ . }}</p>
+    {{ end }}
+
+    {{ if and $linkcontent $linkurl (not ($page.Param "paige.file_link.disable")) }}
+    <p class="text-center" id="paige-file-link">
+        <a class="link-secondary" href="{{ $linkurl }}">{{ $linkcontent }}</a>
+    </p>
     {{ end }}
 
     <p class="mb-0 text-center" id="paige-credit">

--- a/themes/paige/layouts/partials/paige/links.html
+++ b/themes/paige/layouts/partials/paige/links.html
@@ -42,6 +42,6 @@
 {{ if .AlternativeOutputFormats }}
     {{ $title := partial "paige/title.html" $page }}
     {{ range .AlternativeOutputFormats }}
-        <link href="{{ .Permalink | safeURL }}" rel="{{ .Rel }}" title="{{ $title }}" type="{{ .MediaType.Type }}">
+        {{ printf `<link href="%s" rel="%s" type="%s">` (.Permalink | safeURL) .Rel .MediaType | safeHTML }}
     {{ end }}
 {{ end }}

--- a/themes/paige/layouts/partials/paige/target.html
+++ b/themes/paige/layouts/partials/paige/target.html
@@ -1,0 +1,8 @@
+{{ $params := . }}
+
+{{ $page := $params.page }}
+{{ $url := $params.url }}
+
+{{ $external := cond (urls.Parse $url).IsAbs (not (strings.HasSuffix $url site.BaseURL)) false }}
+
+{{ return cond (and $external ($page.Param "paige.external_link_new_tab" | not | not)) "_blank" "" }}


### PR DESCRIPTION
- Adding 'edit link' ability to blog pages. 
- Set header font color in `style-first.css`. 
- Also, set menu font color sitewide in `hugo.toml`.
- Removed page-level menu font colors.
- Removed page-level heading font colors. 