### PR TITLE
Updated go version number to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/pbj-writes/hugo_portfolio
 
-go 1.21.0
+go 1.23.0
 
 require github.com/willfaught/paige v0.65.5 // indirect


### PR DESCRIPTION
Fixing build and deploy issues due to go version number discrepancy.